### PR TITLE
Update react-native-keep-awake.podspec

### DIFF
--- a/react-native-keep-awake.podspec
+++ b/react-native-keep-awake.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
s.dependancy should be updated to React-Core as per https://github.com/facebook/react-native/issues/29633#issuecomment-694187116 as it causes the xcode build to fail without legacy build