### PR TITLE
fix build android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.sayem.keepawake" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
> Task :sayem314_react-native-keep-awake:processReleaseManifest
package="com.sayem.keepawake" found in source AndroidManifest.xml: ../node_modules/@sayem314/react-native-keep-awake/android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="com.sayem.keepawake" from the source AndroidManifest.xml: .../node_modules/@sayem314/react-native-keep-awake/android/src/main/AndroidManifest.xml.

This MR fix above error while building android